### PR TITLE
doc(package): fix author name

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier": "prettier --config .prettierrc --write .",
     "test:watch": "jest --watch"
   },
-  "author": "Jakub Synowiec <jsynowiec@users.noreply.github.com>",
+  "author": "Vitor <vi.souza.almeida@protonmail.com>",
   "license": "MIT",
   "dependencies": {
     "tslib": "~2.4"


### PR DESCRIPTION
I cloned [this repo](https://github.com/jsynowiec/node-typescript-boilerplate) to get a typescript boilerplate and forgot to rename the package